### PR TITLE
Feature/app disconnect

### DIFF
--- a/app/src/main/java/MyStomp.kt
+++ b/app/src/main/java/MyStomp.kt
@@ -33,6 +33,7 @@ class MyStomp(val callbacks: Callbacks) {
 
     private lateinit var activeSession: StompSession
 
+    private var connected = false
     companion object {
         lateinit var instance: MyStomp
     }
@@ -51,17 +52,35 @@ class MyStomp(val callbacks: Callbacks) {
                 Log.d("STOMP", "CONNECTED -> session = $activeSession")
                 // connect to topic lobby-response
                 lobbyFlow = activeSession.subscribeText("/topic/lobby-response")
+               /*
                 lobbyCollector = scope.launch {
                     lobbyFlow?.collect { msg ->
                         // For Debugging
                         Log.d("MyStomp", "Received lobby-response: $msg")
                         LobbyHandler.handle(msg)
                     }
+
+
+                }
+                //
+                */
+                lobbyCollector = scope.launch {
+                    try {
+                        lobbyFlow?.collect { msg ->
+                            Log.d("MyStomp", "Received lobby-response: $msg")
+                            LobbyHandler.handle(msg)
+                        }
+                    } catch (e: Exception) {
+                        Log.e("MyStomp", "Lobby connection lost", e)
+                        // Nicht crashen! Einfach still beenden
+                    }
                 }
                 callback("connected")
 
                 // connect to topic game-response
                 gameFlow = activeSession.subscribeText("/topic/game-response")
+
+                /*
                 gameCollector = scope.launch {
                     gameFlow?.collect { msg ->
                         // For Debugging
@@ -70,6 +89,19 @@ class MyStomp(val callbacks: Callbacks) {
                     }
                 }
 
+
+                 */
+                gameCollector = scope.launch {
+                    try {
+                        gameFlow?.collect { msg ->
+                            Log.d("MyStomp", "Received game-response: $msg")
+                            GameHandler.handle(msg)
+                        }
+                    } catch (e: Exception) {
+                        Log.e("MyStomp", "Game connection lost", e)
+                        // Nicht crashen!
+                    }
+                }
                 callback("connected")
                 val payload = JSONObject()
                 payload.put("playerKey", ClientState.playerId)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/GameActivity.kt
@@ -14,7 +14,7 @@ import com.example.myapplication.R
 import at.aau.serg.websocketbrokerdemo.model.BoardConfig
 import at.aau.serg.websocketbrokerdemo.model.ClientState
 import at.aau.serg.websocketbrokerdemo.network.game.GameHandler
-
+import android.content.Intent
 class GameActivity : ComponentActivity() {
     private lateinit var rootLayout: ViewGroup
     private lateinit var boardImage: ImageView
@@ -419,6 +419,31 @@ class GameActivity : ComponentActivity() {
                         "${winner.take(8)}..."
                     )
                 GameUIHelper.showGameEndOverlay(this, rootLayout, msg)
+            }
+        }
+
+        GameHandler.onGameAborted = { reason ->
+            runOnUiThread {
+                GameUIHelper.showGameEndOverlay(
+                    this,
+                    rootLayout,
+                    getString(R.string.game_over, reason)
+                )
+            }
+        }
+        GameHandler.onGamePaused = { disconnectedId, countdown ->
+            runOnUiThread {
+                Toast.makeText(this,
+                    "player disconnected! $countdown Sekunden zum Rejoin",
+                    Toast.LENGTH_LONG).show()
+            }
+        }
+
+        GameHandler.onContinueGame = { rejoinedId ->
+            runOnUiThread {
+                Toast.makeText(this,
+                    "player back! Game resumed.",
+                    Toast.LENGTH_SHORT).show()
             }
         }
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
@@ -37,6 +37,15 @@ class MainActivity : ComponentActivity(), Callbacks {
             }
         }
 
+        LobbyHandler.onPlayerRejoined = { dto ->
+            runOnUiThread {
+                if (ClientState.gameStatus == "RUNNING") {
+                    startActivity(Intent(this, GameActivity::class.java))
+                } else {
+                    startActivity(Intent(this, LobbyActivity::class.java))
+                }
+            }
+        }
         setContentView(R.layout.cluedo_fragment_fullscreen)
 
         val btnLearn = findViewById<Button>(R.id.btnLearn)

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/messaging/dtos/GameMessageType.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/messaging/dtos/GameMessageType.kt
@@ -11,6 +11,8 @@ enum class GameMessageType {
     SUGGESTION_RESULT,
     SUGGESTION_ERROR,
     GAME_FINISHED,
+    GAME_PAUSED,
+    CONTINUE_GAME,
     GAME_ABORTED
 
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/messaging/dtos/lobbyDTO/PlayerRejoinedPayload.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/messaging/dtos/lobbyDTO/PlayerRejoinedPayload.kt
@@ -5,5 +5,10 @@ import at.aau.serg.websocketbrokerdemo.messaging.dtos.ExistingPlayerDTO
 data class PlayerRejoinedPayload(
     val playerId: String,
     val existingPlayers: List<ExistingPlayerDTO>,
-    val availableCharacters: List<String> = emptyList()
+    val availableCharacters: List<String> = emptyList(),
+    val gameStatus: String = "LOBBY",
+    val currentPlayerId: String = "",
+    val currentPhase: String = "",
+    val myCards: List<String> = emptyList(),
+    val characterType: String = ""
 )

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/model/ClientState.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/model/ClientState.kt
@@ -3,6 +3,7 @@ package at.aau.serg.websocketbrokerdemo.model
 import at.aau.serg.websocketbrokerdemo.messaging.dtos.ExistingPlayerDTO
 
 object ClientState {
+    lateinit var gameStatus: String
     var availableCharacters: List<String> = emptyList()
 
     // Player
@@ -18,6 +19,7 @@ object ClientState {
 
     // Gamestate
     var currentPlayerId: String = ""
+
     var remainingMoves: Int = 0
     var playerPositions: MutableMap<String, String> = mutableMapOf()
      var currentPhase: String = ""

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/game/GameHandler.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/game/GameHandler.kt
@@ -16,6 +16,8 @@ class GameHandler {
         var onSuggestionResult: ((String, String, String, String, List<String>) -> Unit)? = null
         var onGameFinished: ((String) -> Unit)? = null
         var onGameAborted: ((String) -> Unit)? = null
+        var onGamePaused: ((String, Int) -> Unit)? = null
+        var onContinueGame: ((String) -> Unit)? = null
         fun handle(msg: String) {
             try {
                 val json = JSONObject(msg)
@@ -114,6 +116,16 @@ class GameHandler {
                     GameMessageType.GAME_FINISHED.name -> {
                         val winner = payload?.optString("winner", "") ?: ""
                         onGameFinished?.invoke(winner)
+                    }
+                    GameMessageType.GAME_PAUSED.name -> {
+                        val disconnectedId = payload?.optString("disconnectedPlayerId") ?: ""
+                        val countdown = payload?.optInt("countdown") ?: 30
+                        onGamePaused?.invoke(disconnectedId, countdown)
+                    }
+
+                    GameMessageType.CONTINUE_GAME.name -> {
+                        val rejoinedId = payload?.optString("rejoinedPlayerId") ?: ""
+                        onContinueGame?.invoke(rejoinedId)
                     }
 
                     GameMessageType.GAME_ABORTED.name -> {

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/game/GameHandler.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/game/GameHandler.kt
@@ -118,6 +118,8 @@ class GameHandler {
 
                     GameMessageType.GAME_ABORTED.name -> {
                         val reason = payload?.optString("reason", "Game aborted") ?: "Game aborted"
+                        ClientState.gameStatus = "LOBBY"
+
                         onGameAborted?.invoke(reason)
                     }
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/lobby/LobbyHandler.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/lobby/LobbyHandler.kt
@@ -48,10 +48,12 @@ object LobbyHandler {
                 if (dto.availableCharacters.isNotEmpty()) {
                     ClientState.availableCharacters = dto.availableCharacters
                 }
-
+/*
                 if (dto.playerId == ClientState.playerId) {
                     onLobbyJoined?.invoke()
                 }
+
+ */
 
                 onPlayerRejoined?.invoke(dto)
             }
@@ -142,12 +144,18 @@ object LobbyHandler {
     }
 
     private fun parsePlayers(payload: JSONObject): List<ExistingPlayerDTO> {
-        val array = payload.getJSONArray("existingPlayers")
+        //val array = payload.getJSONArray("existingPlayers")
+        val array = if (payload.has("existingPlayers"))
+            payload.getJSONArray("existingPlayers")
+        else
+            payload.getJSONArray("players")
         return (0 until array.length()).map {
             val p = array.getJSONObject(it)
             ExistingPlayerDTO(
                 playerId = p.getString("playerId"),
-                ready = p.getBoolean("ready"),
+                ready = p.optBoolean("ready", false),
+
+               // ready = p.getBoolean("ready"),
                 character = p.optString("characterType")
                     .ifEmpty { p.optString("character") }
                     .takeIf { it.isNotEmpty() },

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/lobby/LobbyHandler.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/network/lobby/LobbyHandler.kt
@@ -42,6 +42,8 @@ object LobbyHandler {
             }
             LobbyMessageType.PLAYER_REJOINED -> {
                 val dto = parsePlayerRejoined(payload)
+                ClientState.gameStatus = payload.optString("gameStatus", "LOBBY") // ← NEU
+
                 ClientState.players = dto.existingPlayers
                 if (dto.availableCharacters.isNotEmpty()) {
                     ClientState.availableCharacters = dto.availableCharacters


### PR DESCRIPTION
When a player disconnects during a running game (RUNNING), the system must handle it as follows:

Detect disconnect via WebSocket session tracking
Mark the player as inactive
Send GAME_PAUSED to all clients
Start a 30-second countdown timer
During countdown:
If the player rejoins in time: cancel timer and send CONTINUE_GAME
If not: abort the game and send GAME_ABORTED