### PR TITLE
Fix/automatic lobby leave

### DIFF
--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/LobbyActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/LobbyActivity.kt
@@ -226,17 +226,22 @@ class LobbyActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
-        LobbyHandler.onLobbyJoined = null
-        LobbyHandler.onNewPlayerJoined = null
-        LobbyHandler.onPlayerRejoined = null
-        LobbyHandler.onPlayerRejoinedRunning = null
-        LobbyHandler.onGameFull = null
-        LobbyHandler.onPlayerRemoved = null
-        LobbyHandler.onOtherPlayerRemoved = null
-        LobbyHandler.onSetReady = null
-        LobbyHandler.onGameStarted = null
-        LobbyHandler.onStartGameError = null
-        LobbyHandler.onError = null
+        // Only clear callbacks when the system destroys us (e.g. config change).
+        // When isLeaving is true, MainActivity is already setting up its own
+        // callbacks in onStart() — clearing here would null them out.
+        if (!isLeaving) {
+            LobbyHandler.onLobbyJoined = null
+            LobbyHandler.onNewPlayerJoined = null
+            LobbyHandler.onPlayerRejoined = null
+            LobbyHandler.onPlayerRejoinedRunning = null
+            LobbyHandler.onGameFull = null
+            LobbyHandler.onPlayerRemoved = null
+            LobbyHandler.onOtherPlayerRemoved = null
+            LobbyHandler.onSetReady = null
+            LobbyHandler.onGameStarted = null
+            LobbyHandler.onStartGameError = null
+            LobbyHandler.onError = null
+        }
         super.onDestroy()
     }
 

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/LobbyActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/LobbyActivity.kt
@@ -213,6 +213,18 @@ class LobbyActivity : ComponentActivity() {
     }
 
 
+    override fun onUserLeaveHint() {
+        super.onUserLeaveHint()
+        if (isLeaving) return
+        isLeaving = true
+        MyStomp.instance.leaveLobby()
+        MyStomp.instance.disconnect()
+        val intent = Intent(this, MainActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+        startActivity(intent)
+        finish()
+    }
+
     override fun onDestroy() {
         LobbyHandler.onLobbyJoined = null
         LobbyHandler.onNewPlayerJoined = null

--- a/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
+++ b/app/src/main/java/at/aau/serg/websocketbrokerdemo/MainActivity.kt
@@ -18,10 +18,6 @@ class MainActivity : ComponentActivity(), Callbacks {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Always create a fresh MyStomp — it resets internal state cleanly
-        // and keeps the CoroutineScope alive for reconnection.
-        myStomp = MyStomp(this)
-
         val playerId = UserPreferences.getOrCreatePlayerId(this)
         ClientState.playerId = playerId
 
@@ -29,7 +25,27 @@ class MainActivity : ComponentActivity(), Callbacks {
 
         setContentView(R.layout.cluedo_fragment_fullscreen)
 
+        val btnLearn = findViewById<Button>(R.id.btnLearn)
+        btnLearn.setOnClickListener {
+            val intent = Intent(this, LearnActivity::class.java)
+            startActivity(intent)
+        }
+
+        val btnStart = findViewById<Button>(R.id.btnStart)
+        btnStart.setOnClickListener {
+            findViewById<android.widget.FrameLayout>(R.id.loadingOverlay).visibility = android.view.View.VISIBLE
+            myStomp.connect()
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        // Re-create MyStomp so we get a clean session on every (re-)visit
+        myStomp = MyStomp(this)
+
         val loadingOverlay = findViewById<android.widget.FrameLayout>(R.id.loadingOverlay)
+        loadingOverlay.visibility = android.view.View.GONE
 
         LobbyHandler.onLobbyJoined = {
             runOnUiThread {
@@ -53,21 +69,6 @@ class MainActivity : ComponentActivity(), Callbacks {
                 startActivity(Intent(this, GameActivity::class.java))
             }
         }
-
-        val btnLearn = findViewById<Button>(R.id.btnLearn)
-
-        btnLearn.setOnClickListener {
-            val intent = Intent(this, LearnActivity::class.java)
-            startActivity(intent)
-        }
-
-
-        val btnStart = findViewById<Button>(R.id.btnStart)
-        btnStart.setOnClickListener {
-            loadingOverlay.visibility = android.view.View.VISIBLE
-            myStomp.connect()
-        }
-
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
Implemented lobby disconnect on system navigation buttons (home, back, and task switcher). The app now automatically sends a leave message to the server and disconnects when exiting the lobby through any of these buttons — no longer requiring the user to manually press "Leave." This ensures players don't occupy lobby spots after closing the app, and rejoining works seamlessly without needing to force-close.